### PR TITLE
Fix download to include all items

### DIFF
--- a/templates/demo.html
+++ b/templates/demo.html
@@ -610,6 +610,7 @@
     // State
     let highRiskThreshold = 0.30; // default 30%
     let rowsData = [];
+    let lastUploadedFile = null;
 
     // Helpers
     function showNotification(type, message) {
@@ -732,6 +733,8 @@
         return;
       }
 
+      lastUploadedFile = file;
+
       resultsContainer.style.display = 'none';
       loadingSpinner.style.display = 'block';
       const formData = new FormData();
@@ -768,29 +771,61 @@
         });
     }
 
-    // Download functionality (export CSV)
+    // Download functionality (export full Excel)
     window.downloadResults = function () {
-      if (!window.analysisData || !Array.isArray(window.analysisData.results)) {
-        showNotification('info', 'No data available to download.');
+      if (!lastUploadedFile) {
+        showNotification('info', 'Please upload a file first to download the full results.');
         return;
       }
-      const data = window.analysisData.results;
-      let csvContent = 'Customer Number,Customer Lifetime Value,Churn Probability,Risk Level,Recommendation\n';
-      data.forEach((row, index) => {
-        const clv = Number(row.Predicted_CLV);
-        const churnProb = Number(row.Churn_Probability);
-        const risk = getRiskInfo(churnProb);
-        csvContent += `${index + 1},"${formatCurrency(clv)}",${formatPercent(churnProb)},${risk.level},"${risk.recommendation}"\n`;
-      });
-      const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
-      const link = document.createElement('a');
-      const url = URL.createObjectURL(blob);
-      link.href = url;
-      link.download = 'customer_analysis_results.csv';
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      URL.revokeObjectURL(url);
+
+      showNotification('info', 'Preparing your full Excel download...');
+
+      const formData = new FormData();
+      formData.append('file', lastUploadedFile);
+
+      fetch('/predict/', { method: 'POST', body: formData })
+        .then(async (response) => {
+          if (!response.ok) {
+            showNotification('error', 'Failed to generate the full results file.');
+            return null;
+          }
+          try {
+            return await response.json();
+          } catch (err) {
+            showNotification('error', 'Invalid response from server while generating download.');
+            return null;
+          }
+        })
+        .then((data) => {
+          if (!data || !data.success || !data.excel_base64) {
+            const errMsg = (data && data.error) ? data.error : 'Unable to create the full results file.';
+            showNotification('error', errMsg);
+            return;
+          }
+
+          const base64 = data.excel_base64;
+          const byteChars = atob(base64);
+          const byteNumbers = new Array(byteChars.length);
+          for (let i = 0; i < byteChars.length; i++) {
+            byteNumbers[i] = byteChars.charCodeAt(i);
+          }
+          const byteArray = new Uint8Array(byteNumbers);
+          const blob = new Blob([byteArray], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+          const url = URL.createObjectURL(blob);
+          const link = document.createElement('a');
+          link.href = url;
+          link.download = 'customer_analysis_results.xlsx';
+          document.body.appendChild(link);
+          link.click();
+          document.body.removeChild(link);
+          URL.revokeObjectURL(url);
+
+          showNotification('success', 'Full results downloaded successfully.');
+        })
+        .catch((error) => {
+          console.error('Download error:', error);
+          showNotification('error', 'An error occurred while downloading the full results.');
+        });
     };
   });
 </script>


### PR DESCRIPTION
Update 'Download Full Results' to export the complete dataset instead of only the 10 visible rows.

---
<a href="https://cursor.com/background-agent?bcId=bc-ba2ee2a6-edfe-40a5-bdef-119d6be7286a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ba2ee2a6-edfe-40a5-bdef-119d6be7286a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

